### PR TITLE
fix build on cpu container

### DIFF
--- a/config/conda_build_config.yaml
+++ b/config/conda_build_config.yaml
@@ -1,0 +1,5 @@
+build_type:
+  - "cpu"
+
+pytorch_select_version:
+  - "1.0"

--- a/lightning/meta.yaml
+++ b/lightning/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   string: py_{{ PKG_BUILDNUM }}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
@@ -33,6 +33,8 @@ requirements:
     - torchmetrics {{ torchmetrics }}
 
 test:
+  requires:
+    - _pytorch_select  {{ pytorch_select_version }}
   imports:
     - pytorch_lightning
 

--- a/metrics/meta.yaml
+++ b/metrics/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 1 
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -25,6 +25,8 @@ requirements:
     - pytorch-base {{ pytorch }}
  
 test:
+  requires:
+    - _pytorch_select  {{ pytorch_select_version }}
   imports:
     - torchmetrics
 


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Recipe tests failed on CPU container with the following error:

```
from torch._C import *
ImportError: libcupti.so.10.2: cannot open shared object file: No such file or directory
```

because it used CUDA `pytorch-base`. And import torch fails for cuda `pytorch-base` on CPU container due to unavailability of CUDA libs.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
