### PR TITLE
update pytorch-lightning to v1.5.9 and revert pydeprecate to v0.3.1

### DIFF
--- a/lightning/meta.yaml
+++ b/lightning/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytorch-lightning" %}
-{% set version = "1.5.7" %}
+{% set version = "1.5.9" %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 2
+  number: 1
   noarch: python
   string: pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv

--- a/lightning/meta.yaml
+++ b/lightning/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   string: pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
@@ -31,7 +31,7 @@ requirements:
     - tqdm  {{ tqdm }}
     - fsspec {{ fsspec }}
     - torchmetrics {{ torchmetrics }}
-    - pyDeprecate 0.3.2
+    - pyDeprecate 0.3.1
 test:
   imports:
     - pytorch_lightning

--- a/pydeprecate/meta.yaml
+++ b/pydeprecate/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyDeprecate" %}
-{% set version = "0.3.2" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d481116cc5d7f6c473e7c4be820efdd9b90a16b594b350276e9e66a6cb5bdd29
+  sha256: fa26870924d3475621c344045c2c01a16ba034113a902600c78e75b3fac5f72c
 
 build:
   noarch: python


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

- update `pytorch-lightning` to v1.5.9
- revert `pydeprecate `to v0.3.1
- update the `pydeprecate `pin in lightning recipe.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
