### PR TITLE
fix conflict observed during build

### DIFF
--- a/lightning-app/meta.yaml
+++ b/lightning-app/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 2
+  number: 3
   noarch: python
   string: pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script: export PACKAGE_NAME=app; {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
@@ -38,7 +38,8 @@ requirements:
     - croniter
     - backoff
     - starsessions >=1.2.1, <2.0
-    - s3fs >=2022.5.0, <=2023.10.0
+    # disable s3fs for PPC because v2023.10.0 is not available on PPC
+    #- s3fs >=2022.5.0, <=2023.10.0    #[x86_64]
     - arrow >=1.2.0, <1.2.4
     - traitlets >=5.3.0, <5.9.0
     - psutil {{ psutil }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

s3fs v23.10.0 which is compatible with fsspec v23.10.0 is not available on PPC. 

A solution here could be to build s3fs 23.10.0, but it requires numerous other deps also to be built. Thus removing s3fs from run deps for PPC. The package gets built with this change. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
