### PR TITLE
Add a filter to use run time pin of setuptools vesrion based on the respective platform

### DIFF
--- a/config/build-config.yaml
+++ b/config/build-config.yaml
@@ -1,12 +1,12 @@
 recipes:
+  - name : lightning-utilities
+    path : lightning-utilities
+
   - name : torchmetrics
     path : metrics
 
   - name : pytorch-lightning
     path : lightning
-
-  - name : lightning-utilities
-    path : lightning-utilities
 
   - name : lightning-cloud
     path : lightning-cloud

--- a/lightning-utilities/meta.yaml
+++ b/lightning-utilities/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 3
   noarch: python
   string: pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed . -vv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -23,10 +23,13 @@ requirements:
     - python
     - fire
     - packaging
+    - typing_extensions >=4.0,<5
+    - setuptools >=78.1.1
 
 test:
   requires:
-    - setuptools
+    - typing_extensions >=4.0,<5
+    - setuptools >=78.1.1
   imports:
     - lightning_utilities
   commands:

--- a/lightning-utilities/meta.yaml
+++ b/lightning-utilities/meta.yaml
@@ -24,12 +24,13 @@ requirements:
     - fire
     - packaging
     - typing_extensions >=4.0,<5
-    - setuptools >=78.1.1
-
+    - setuptools >=78.1.1  #[x86]
+    - setuptools           #[not x86]
 test:
   requires:
     - typing_extensions >=4.0,<5
-    - setuptools >=78.1.1
+    - setuptools >=78.1.1  #[x86]
+    - setuptools           #[not x86]
   imports:
     - lightning_utilities
   commands:

--- a/metrics/meta.yaml
+++ b/metrics/meta.yaml
@@ -20,7 +20,8 @@ requirements:
     - python
   run:
     - packaging
-    - setuptools >=78.1.1
+    - setuptools >=78.1.1    #[x86]
+    - setuptools             #[not x86]
     - python 
     - pytorch-base {{ pytorch }}
     - tqdm {{ tqdm }}

--- a/metrics/meta.yaml
+++ b/metrics/meta.yaml
@@ -20,11 +20,11 @@ requirements:
     - python
   run:
     - packaging
-    - setuptools
+    - setuptools >=78.1.1
     - python 
     - pytorch-base {{ pytorch }}
     - tqdm {{ tqdm }}
-    - lightning-utilities 
+    - lightning-utilities =0.10.0
 
 test:
   imports:


### PR DESCRIPTION

Add a filter to apply a runtime pin for the setuptools version depending on the respective platform. **P** pinned at 68.0.0 and **X** pin at 78.1.1 